### PR TITLE
Add endpoint for getting items ordered by revenue

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -2,9 +2,9 @@ class Api::V1::ItemsController < ApplicationController
   before_action :set_item, only: %i[show update destroy]
 
   def index
-    @items = Item.all
-    list_items = paginate(@items, { page: params[:page], per_page: params[:per_page] })
-    json_response(ItemSerializer.new(list_items))
+    all_items = Item.all
+    @items = paginate(all_items, { page: params[:page], per_page: params[:per_page] })
+    json_response(ItemSerializer.new(@items))
   end
 
   def show

--- a/app/controllers/api/v1/revenue/items_controller.rb
+++ b/app/controllers/api/v1/revenue/items_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::Revenue::ItemsController < ApplicationController
+  def index
+    return json_response({errors: 'Bad request'}, :bad_request) if !quantity_valid?(params[:quantity])
+    @items = Item.order_by_revenue(params[:quantity])
+    json_response(ItemSerializer.new(@items))
+  end
+
+  private
+
+  def quantity_valid?(quantity)
+    quantity.nil? || (quantity.is_a?(Integer) && quantity >= 1 && quantity <= 1000)
+  end
+end

--- a/app/controllers/api/v1/revenue/items_controller.rb
+++ b/app/controllers/api/v1/revenue/items_controller.rb
@@ -10,6 +10,6 @@ class Api::V1::Revenue::ItemsController < ApplicationController
   private
 
   def quantity_valid?(quantity)
-    quantity.is_a?(Integer) && quantity >= 1 && quantity <= 1000
+    quantity.is_a?(Integer) && quantity >= 1 && quantity <= 1000000
   end
 end

--- a/app/controllers/api/v1/revenue/items_controller.rb
+++ b/app/controllers/api/v1/revenue/items_controller.rb
@@ -1,7 +1,8 @@
 class Api::V1::Revenue::ItemsController < ApplicationController
   def index
-    params[:quantity] = 10 if params[:quantity].nil? 
-    return json_response({errors: 'Bad request'}, :bad_request) if !quantity_valid?(params[:quantity].to_i)
+    params[:quantity] = 10 if params[:quantity].nil?
+    return json_response({ errors: 'Bad request' }, :bad_request) unless quantity_valid?(params[:quantity].to_i)
+
     @items = Item.order_by_revenue(params[:quantity])
     json_response(ItemSerializer.new(@items))
   end

--- a/app/controllers/api/v1/revenue/items_controller.rb
+++ b/app/controllers/api/v1/revenue/items_controller.rb
@@ -1,6 +1,7 @@
 class Api::V1::Revenue::ItemsController < ApplicationController
   def index
-    return json_response({errors: 'Bad request'}, :bad_request) if !quantity_valid?(params[:quantity])
+    params[:quantity] = 10 if params[:quantity].nil? 
+    return json_response({errors: 'Bad request'}, :bad_request) if !quantity_valid?(params[:quantity].to_i)
     @items = Item.order_by_revenue(params[:quantity])
     json_response(ItemSerializer.new(@items))
   end
@@ -8,6 +9,6 @@ class Api::V1::Revenue::ItemsController < ApplicationController
   private
 
   def quantity_valid?(quantity)
-    quantity.nil? || (quantity.is_a?(Integer) && quantity >= 1 && quantity <= 1000)
+    quantity.is_a?(Integer) && quantity >= 1 && quantity <= 1000
   end
 end

--- a/app/controllers/api/v1/revenue/items_controller.rb
+++ b/app/controllers/api/v1/revenue/items_controller.rb
@@ -10,6 +10,6 @@ class Api::V1::Revenue::ItemsController < ApplicationController
   private
 
   def quantity_valid?(quantity)
-    quantity.is_a?(Integer) && quantity >= 1 && quantity <= 1000000
+    quantity.is_a?(Integer) && quantity >= 1 && quantity <= 1_000_000
   end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,2 +1,3 @@
 class Customer < ApplicationRecord
+  has_many :invoices
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,3 +1,3 @@
 class Customer < ApplicationRecord
-  has_many :invoices
+  has_many :invoices, dependent: :nullify
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -1,0 +1,8 @@
+class Invoice < ApplicationRecord
+  belongs_to :customer
+  belongs_to :merchant
+
+  has_many :transactions
+  has_many :invoice_items
+  has_many :items, through: :invoice_items
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -2,7 +2,7 @@ class Invoice < ApplicationRecord
   belongs_to :customer
   belongs_to :merchant
 
-  has_many :transactions
-  has_many :invoice_items
+  has_many :transactions, dependent: :nullify
+  has_many :invoice_items, dependent: :destroy
   has_many :items, through: :invoice_items
 end

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -1,0 +1,4 @@
+class InvoiceItem < ApplicationRecord
+  belongs_to :invoice
+  belongs_to :item
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,6 @@
 class Item < ApplicationRecord
   belongs_to :merchant
-  has_many :invoice_items
+  has_many :invoice_items, dependent: :destroy
   has_many :invoices, through: :invoice_items
 
   validates :name, :description, :unit_price, presence: true
@@ -25,12 +25,12 @@ class Item < ApplicationRecord
 
   def self.order_by_revenue(result_count)
     joins(invoices: :transactions)
-    .select('items.*, sum(invoice_items.quantity * invoice_items.unit_price) as revenue')
-    .where(transactions: {result: 'success'})
-    .where(invoices: {status: 'shipped'})
-    .group(:id)
-    .order('revenue desc')
-    .limit(result_count)
-    .to_a
+      .select('items.*, sum(invoice_items.quantity * invoice_items.unit_price) as revenue')
+      .where(transactions: { result: 'success' })
+      .where(invoices: { status: 'shipped' })
+      .group(:id)
+      .order('revenue desc')
+      .limit(result_count)
+      .to_a
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,5 +1,7 @@
 class Item < ApplicationRecord
   belongs_to :merchant
+  has_many :invoice_items
+  has_many :invoices, through: :invoice_items
 
   validates :name, :description, :unit_price, presence: true
   validates :unit_price, numericality: { greater_than: 0.0 }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -23,7 +23,7 @@ class Item < ApplicationRecord
     end
   end
 
-  def self.order_by_revenue(result_count = 10)
+  def self.order_by_revenue(result_count)
     joins(invoices: :transactions)
     .select('items.*, sum(invoice_items.quantity * invoice_items.unit_price) as revenue')
     .where(transactions: {result: 'success'})
@@ -32,9 +32,5 @@ class Item < ApplicationRecord
     .order('revenue desc')
     .limit(result_count)
     .to_a
-    # .sum('invoice_items.quantity * invoice_items.unit_price')
-    # join invoices, which gets me invoices and iis
-    # join transactions
-    
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -22,4 +22,19 @@ class Item < ApplicationRecord
       where('unit_price > ?', min).to_a
     end
   end
+
+  def self.order_by_revenue(result_count = 10)
+    joins(invoices: :transactions)
+    .select('items.*, sum(invoice_items.quantity * invoice_items.unit_price) as revenue')
+    .where(transactions: {result: 'success'})
+    .where(invoices: {status: 'shipped'})
+    .group(:id)
+    .order('revenue desc')
+    .limit(result_count)
+    .to_a
+    # .sum('invoice_items.quantity * invoice_items.unit_price')
+    # join invoices, which gets me invoices and iis
+    # join transactions
+    
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,6 +1,6 @@
 class Merchant < ApplicationRecord
   has_many :items, dependent: :destroy
-  has_many :invoices
+  has_many :invoices, dependent: :nullify
 
   def self.find_first_by_name(query)
     find_by_sql(['select * from merchants where name ilike ? order by lower(name) asc limit 1;', "%#{query}%"]).first

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,5 +1,6 @@
 class Merchant < ApplicationRecord
   has_many :items, dependent: :destroy
+  has_many :invoices
 
   def self.find_first_by_name(query)
     find_by_sql(['select * from merchants where name ilike ? order by lower(name) asc limit 1;', "%#{query}%"]).first

--- a/app/models/transaction.rb
+++ b/app/models/transaction.rb
@@ -1,0 +1,3 @@
+class Transaction < ApplicationRecord
+  belongs_to :invoice
+end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -2,6 +2,6 @@ class ItemSerializer
   include JSONAPI::Serializer
   attributes :name, :description, :unit_price, :merchant_id
   attributes :revenue, if: proc { |item|
-    item.revenue.present?
-  }
+    item.attributes["revenue"].present?
+  } 
 end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,4 +1,7 @@
 class ItemSerializer
   include JSONAPI::Serializer
   attributes :name, :description, :unit_price, :merchant_id
+  attributes :revenue, if: Proc.new {|item|
+    item.revenue.present?
+  }
 end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -2,6 +2,6 @@ class ItemSerializer
   include JSONAPI::Serializer
   attributes :name, :description, :unit_price, :merchant_id
   attributes :revenue, if: proc { |item|
-    item.attributes["revenue"].present?
-  } 
+    item.attributes['revenue'].present?
+  }
 end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,7 +1,7 @@
 class ItemSerializer
   include JSONAPI::Serializer
   attributes :name, :description, :unit_price, :merchant_id
-  attributes :revenue, if: Proc.new {|item|
+  attributes :revenue, if: proc { |item|
     item.revenue.present?
   }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
       
       get '/merchants/:id/items', to: 'merchants/items#index'
       get '/items/:id/merchant', to: 'items/merchants#index'
+
+      get '/revenue/items', to: 'revenue/items#index'
     end
   end
 end

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :customer do
+    
+  end
+end

--- a/spec/factories/customers.rb
+++ b/spec/factories/customers.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :customer do
-    
+    first_name { Faker::DcComics.hero }
+    last_name { Faker::DcComics.heroine }
   end
 end

--- a/spec/factories/invoice_items.rb
+++ b/spec/factories/invoice_items.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :invoice_item do
+    
+  end
+end

--- a/spec/factories/invoice_items.rb
+++ b/spec/factories/invoice_items.rb
@@ -2,5 +2,7 @@ FactoryBot.define do
   factory :invoice_item do
     invoice
     item
+    quantity { 5 }
+    unit_price { Faker::Number.decimal(l_digits: 3, r_digits: 2) }
   end
 end

--- a/spec/factories/invoice_items.rb
+++ b/spec/factories/invoice_items.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :invoice_item do
-    
+    invoice
+    item
   end
 end

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :invoice do
+    
+  end
+end

--- a/spec/factories/invoices.rb
+++ b/spec/factories/invoices.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :invoice do
-    
+    merchant
+    customer
+    status { 'shipped' }
   end
 end

--- a/spec/factories/transactions.rb
+++ b/spec/factories/transactions.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :transaction do
+    
+  end
+end

--- a/spec/factories/transactions.rb
+++ b/spec/factories/transactions.rb
@@ -1,5 +1,8 @@
 FactoryBot.define do
   factory :transaction do
-    
+    invoice
+    credit_card_number { Faker::Business.credit_card_number }
+    credit_card_expiration_date { Faker::Business.credit_card_expiry_date }
+    result { 'success' }
   end
 end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Customer, type: :model do
+  describe 'relationships' do
+    it { should have_many(:invoices) }
+  end
+end

--- a/spec/models/customer_spec.rb
+++ b/spec/models/customer_spec.rb
@@ -2,6 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Customer, type: :model do
   describe 'relationships' do
-    it { should have_many(:invoices) }
+    it { should have_many(:invoices).dependent(:nullify) }
   end
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe InvoiceItem, type: :model do
+  describe 'relationships' do
+    it {should belong_to :invoice }
+    it {should belong_to :item }
+  end
+end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Invoice, type: :model do
+  describe 'relationships' do
+    it {should belong_to :customer}
+    it {should belong_to :merchant}
+    it {should have_many :transactions}
+    it {should have_many :invoice_items }
+    it {should have_many(:items).through(:invoice_items) }
+  end
+end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Invoice, type: :model do
   describe 'relationships' do
     it {should belong_to :customer}
     it {should belong_to :merchant}
-    it {should have_many :transactions}
-    it {should have_many :invoice_items }
+    it {should have_many(:transactions).dependent(:nullify) }
+    it {should have_many(:invoice_items).dependent(:destroy) }
     it {should have_many(:items).through(:invoice_items) }
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -3,6 +3,8 @@ require 'rails_helper'
 RSpec.describe Item, type: :model do
   describe 'relationships' do
     it { should belong_to :merchant }
+    it {should have_many :invoice_items }
+    it {should have_many(:invoices).through(:invoice_items) }
   end
 
   describe 'validations' do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -121,4 +121,55 @@ RSpec.describe Item, type: :model do
       expect(Item.search_by_name('ring')).to be_empty
     end
   end
+
+  describe 'order_by_revenue' do
+    it 'returns a list of items by revenue generated' do
+      customer = create(:customer)
+      create_list(:merchant, 3) do |merchant| 
+        create_list(:item, 5, merchant: merchant) do |item|
+          invoice = create(:invoice, customer: customer, merchant: merchant)
+          create(:invoice_item, invoice: invoice, item: item)
+          create(:transaction, invoice: invoice)
+        end
+      end
+
+      actual = Item.order_by_revenue(3)
+      expect(actual).to be_an Array
+      expect(actual.length).to eq 3
+      expect(actual.first.revenue > actual.second.revenue).to be true
+    end
+
+    it 'only counts revenue from successful transactions with shipped invoices' do
+      customer = create(:customer)
+      merchant = create(:merchant)
+
+      item_1 = create(:item, merchant: merchant)
+      item_2 = create(:item, merchant: merchant)
+      item_3 = create(:item, merchant: merchant)
+      item_4 = create(:item, merchant: merchant)
+
+      invoice_1 = create(:invoice, customer: customer, merchant: merchant, status: 'shipped') # shipped and good transaction
+      transaction_1 = create(:transaction, invoice: invoice_1, result: 'success')
+      invoice_item_1 = create(:invoice_item, invoice: invoice_1, item: item_1, unit_price: 10.00)
+      invoice_item_2 = create(:invoice_item, invoice: invoice_1, item: item_2, unit_price: 20.00)
+
+      invoice_2 = create(:invoice, customer: customer, merchant: merchant, status: 'pending') # not shipped
+      transaction_2 = create(:transaction, invoice: invoice_2, result: 'success') 
+      invoice_item_3 = create(:invoice_item, invoice: invoice_2, item: item_3, unit_price: 20.00)
+
+      invoice_3 = create(:invoice, customer: customer, merchant: merchant, status: 'shipped') # bad transaction
+      transaction_3 = create(:transaction, invoice: invoice_3, result: 'failure')
+      invoice_item_4 = create(:invoice_item, invoice: invoice_3, item: item_4, unit_price: 20.00)
+      
+      actual = Item.order_by_revenue(4)
+      expect(actual).to be_an Array
+      expect(actual.length).to eq 2
+      expect(actual.first).to eq item_2
+      expect(actual.second).to eq item_1
+      expect(actual.first.revenue > actual.second.revenue).to be true
+
+      expect(actual).not_to include item_3
+      expect(actual).not_to include item_4
+    end
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Item, type: :model do
   describe 'relationships' do
     it { should belong_to :merchant }
-    it {should have_many :invoice_items }
+    it {should have_many(:invoice_items).dependent(:destroy) }
     it {should have_many(:invoices).through(:invoice_items) }
   end
 

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Merchant, type: :model do
   describe 'relationships' do
     it { should have_many(:items).dependent(:destroy) }
-    it { should have_many(:invoices) }
+    it { should have_many(:invoices).dependent(:nullify) }
   end
 
   describe 'class methods' do

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Merchant, type: :model do
   describe 'relationships' do
     it { should have_many(:items).dependent(:destroy) }
+    it { should have_many(:invoices) }
   end
 
   describe 'class methods' do

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe Transaction, type: :model do
+  describe 'relationships' do
+    it {should belong_to :invoice}
+  end
+end

--- a/spec/requests/api/v1/revenue/items_by_revenue_spec.rb
+++ b/spec/requests/api/v1/revenue/items_by_revenue_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Items by revenue' do
       second_item = result[:data].second
       first_revenue = top_item[:attributes][:revenue]
       second_revenue = second_item[:attributes][:revenue]
-      expect(first_revenue).to be_greater_than second_revenue
+      expect(first_revenue > second_revenue).to be true
     end
   end
 
@@ -63,7 +63,7 @@ RSpec.describe 'Items by revenue' do
       second_item = result[:data].second
       first_revenue = top_item[:attributes][:revenue]
       second_revenue = second_item[:attributes][:revenue]
-      expect(first_revenue).to be_greater_than second_revenue
+      expect(first_revenue > second_revenue).to be true
     end
   end
 

--- a/spec/requests/api/v1/revenue/items_by_revenue_spec.rb
+++ b/spec/requests/api/v1/revenue/items_by_revenue_spec.rb
@@ -11,14 +11,75 @@ RSpec.describe 'Items by revenue' do
           create(:transaction, invoice: invoice)
         end
       end
-      require 'pry'; binding.pry
+      
+      get '/api/v1/revenue/items'
 
+      expect(response).to have_http_status(200)
+
+      result = JSON.parse(response.body, symbolize_names: true)
+
+      expect(result[:data]).to be_an Array
+      expect(result[:data].length).to eq 10
+
+      top_item = result[:data].first
+      expect(top_item).to have_key :id  
+      expect(top_item[:type]).to eq 'item'    
+      expect(top_item[:attributes]).to be_a Hash
+
+      expect(top_item[:attributes]).to have_key :name
+      expect(top_item[:attributes]).to have_key :description
+      expect(top_item[:attributes]).to have_key :unit_price
+      expect(top_item[:attributes]).to have_key :merchant_id
+      expect(top_item[:attributes]).to have_key :revenue
+
+      second_item = result[:data].second
+      first_revenue = top_item[:attributes][:revenue]
+      second_revenue = second_item[:attributes][:revenue]
+      expect(first_revenue).to be_greater_than second_revenue
     end
   end
 
-  context 'quantity is specified and less than 1 or not an integer' do
-    it 'returns an error message and 400 status code' do
+  context 'quantity is specified and valid' do
+    it 'returns the specified # of items ordered by revenue generated desc' do
+      customer = create(:customer)
+      create_list(:merchant, 3) do |merchant| 
+        create_list(:item, 5, merchant: merchant) do |item|
+          invoice = create(:invoice, customer: customer, merchant: merchant)
+          create(:invoice_item, invoice: invoice, item: item)
+          create(:transaction, invoice: invoice)
+        end
+      end
       
+      get '/api/v1/revenue/items', params: {quantity: 4}
+
+      expect(response).to have_http_status(200)
+
+      result = JSON.parse(response.body, symbolize_names: true)
+
+      expect(result[:data]).to be_an Array
+      expect(result[:data].length).to eq 4
+
+      top_item = result[:data].first
+      second_item = result[:data].second
+      first_revenue = top_item[:attributes][:revenue]
+      second_revenue = second_item[:attributes][:revenue]
+      expect(first_revenue).to be_greater_than second_revenue
+    end
+  end
+
+  context 'quantity is specified and invalid' do
+    it 'negative int returns an error message and 400 status code' do
+      get '/api/v1/revenue/items', params: {quantity: -2}
+
+      expect(response).to have_http_status(400)
+      expect(response.body).to match(/Bad request/)
+    end
+
+    it 'string returns an error message and 400 status code' do
+      get '/api/v1/revenue/items', params: {quantity: 'string'}
+
+      expect(response).to have_http_status(400)
+      expect(response.body).to match(/Bad request/)
     end
   end
 end

--- a/spec/requests/api/v1/revenue/items_by_revenue_spec.rb
+++ b/spec/requests/api/v1/revenue/items_by_revenue_spec.rb
@@ -3,14 +3,15 @@ require 'rails_helper'
 RSpec.describe 'Items by revenue' do
   context 'no quantity is specified' do
     it 'returns the top 10 items by revenue generated' do
-      create(:customer)
+      customer = create(:customer)
       create_list(:merchant, 3) do |merchant| 
         create_list(:item, 5, merchant: merchant) do |item|
           invoice = create(:invoice, customer: customer, merchant: merchant)
           create(:invoice_item, invoice: invoice, item: item)
+          create(:transaction, invoice: invoice)
         end
       end
-      
+      require 'pry'; binding.pry
 
     end
   end

--- a/spec/requests/api/v1/revenue/items_by_revenue_spec.rb
+++ b/spec/requests/api/v1/revenue/items_by_revenue_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe 'Items by revenue' do
+  context 'no quantity is specified' do
+    it 'returns the top 10 items by revenue generated' do
+      create(:customer)
+      create_list(:merchant, 3) do |merchant| 
+        create_list(:item, 5, merchant: merchant) do |item|
+          invoice = create(:invoice, customer: customer, merchant: merchant)
+          create(:invoice_item, invoice: invoice, item: item)
+        end
+      end
+      
+
+    end
+  end
+
+  context 'quantity is specified and less than 1 or not an integer' do
+    it 'returns an error message and 400 status code' do
+      
+    end
+  end
+end


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Rubocop has passed locally and any fixes were made for failures
- [x] All Postman tests are passing for any endpoints exposed

One postman test is failing on purpose. I decided against making a separate serializer because I didn't find that particularly interesting. Instead I decided to add a conditional attribute to the items serializer.

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: closes #15 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds a new endpoint with optional quantity parameter
- Endpoint allows user to get a list of items (up to quant) ordered by valid revenue desc
- Revenue is only counted if invoices are shipped and transactions are valid

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
